### PR TITLE
Fix bug in handling of removed zones

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -358,7 +358,7 @@ RoonApiTransport.prototype.subscribe_zones    = function(cb) {
                                             this._zones = msg.zones.reduce((p,e) => (p[e.zone_id] = e) && p, {});
 
                                         } else if (response == "Changed") {
-                                            if (msg.zones_removed)      msg.zones_removed.forEach(e => delete(this._zones[e.zone_id]));
+                                            if (msg.zones_removed)      msg.zones_removed.forEach(zone_id => delete(this._zones[zone_id]));
                                             if (msg.zones_added)        msg.zones_added  .forEach(e => this._zones[e.zone_id] = e);
                                             if (msg.zones_changed)      msg.zones_changed.forEach(e => this._zones[e.zone_id] = e);
                                             

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-roon-api-transport",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Roon Api Transport Service (com.roonlabs.transport:2)",
   "main": "lib.js",
   "author": "Roon Labs, LLC",


### PR DESCRIPTION
When zones are removed the core sends a message with the `zone_id`s of the removed zones, not the complete zone objects as they are interpreted now.

I discovered this while a zone_by_output_id call returned a zone object of a non existing zone after the grouping of zones.